### PR TITLE
Add wrap_event_titles option to wrap long event titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ dim_past_events: true
 show_event_time: true
 time_format: 12h                    # 12h | 24h
 keep_all_day_events_visible: false
+wrap_event_titles: false          # Wrap long titles instead of truncating (Week, Biweek, Today, Next 7 Days)
 show_calendar_grid_lines: true
 event_font_size: 14                 # px
 event_font_family: inherit          # Any CSS font family
@@ -127,6 +128,7 @@ weather_icon_style: static          # static | animated
 | `show_event_time` | boolean | `true` | Show start time on event chips |
 | `time_format` | `12h` \| `24h` | `12h` | Clock format for event times |
 | `keep_all_day_events_visible` | boolean | `false` | Always show all-day events even when scrolled |
+| `wrap_event_titles` | boolean | `false` | Wrap event titles onto multiple lines instead of truncating with an ellipsis (Week, Biweek, Today, Next 7 Days). In duration-based time-grid views, very short events may still look tight since block height follows event duration, not title length. |
 | `show_calendar_grid_lines` | boolean | `true` | Show hour lines in week/day views |
 | `event_font_size` | number | `14` | Event chip font size in px |
 | `event_font_family` | string | `inherit` | Event chip font family |

--- a/custom_components/aurora_calendar/aurora-calendar-card.js
+++ b/custom_components/aurora_calendar/aurora-calendar-card.js
@@ -1787,6 +1787,12 @@ AuroraCalendarMonth.styles = i$3 `
       line-height: 1.05;
     }
 
+    .wrap-titles .chip.all-day-chip {
+      height: auto;
+      min-height: 28px;
+      overflow: visible;
+    }
+
     .all-day-stack .chip.all-day-chip:last-child {
       margin-bottom: 0;
     }
@@ -2574,6 +2580,12 @@ AuroraCalendarWeekBox.styles = i$3 `
       margin-bottom: 2px;
       font-size: var(--aurora-allday-font-size, 13px);
       line-height: 1.05;
+    }
+
+    .wrap-titles .chip.all-day-chip {
+      height: auto;
+      min-height: 28px;
+      overflow: visible;
     }
 
     .all-day-stack .chip.all-day-chip:last-child {

--- a/custom_components/aurora_calendar/aurora-calendar-card.js
+++ b/custom_components/aurora_calendar/aurora-calendar-card.js
@@ -85,6 +85,7 @@ const CONFIG_DEFAULTS = {
     event_font_family: "inherit",
     show_calendar_grid_lines: true,
     keep_all_day_events_visible: false,
+    wrap_event_titles: false,
     glass_background: false,
     card_opacity: 100,
     background_media: null,
@@ -216,6 +217,8 @@ const TRANSLATIONS = {
         viewWeek: "Week",
         tapDayOpensDayView: "Tap day to open day view",
         tapDayOpensDayViewDesc: "Clicking a date number opens that day's detail view",
+        wrapEventTitles: "Wrap event titles",
+        wrapEventTitlesDesc: "Wrap long event titles onto multiple lines instead of truncating them with an ellipsis, in Week and time-grid views. Short-duration time-grid events may still get visually tight since their block height is based on duration, not title length.",
         tapDayAria: "Open day view",
         calendar: "Calendar",
         addEvent: "Add event",
@@ -1242,7 +1245,7 @@ let AuroraCalendarMonth = class AuroraCalendarMonth extends i {
             return formatWeekday(this.locale, date, "short");
         });
         return b `
-      <div class="month-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"}">
+      <div class="month-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"} ${this.config.wrap_event_titles ? "wrap-titles" : ""}">
         <div class="col-headers">
           ${dayHeaders.map((d) => b `<div class="col-header">${d}</div>`)}
         </div>
@@ -1815,6 +1818,13 @@ AuroraCalendarMonth.styles = i$3 `
       text-overflow: ellipsis;
     }
 
+    .wrap-titles .chip-title {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
+    }
+
     .chip-title {
       font-size: 1em;
       font-weight: 800;
@@ -2021,7 +2031,7 @@ let AuroraCalendarWeekBox = class AuroraCalendarWeekBox extends i {
         const days = this.days.slice(0, 7);
         const nextWeekLabel = this._nextWeekLabel(days);
         return b `
-      <div class="week-box-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"}">
+      <div class="week-box-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"} ${this.config.wrap_event_titles ? "wrap-titles" : ""}">
         ${days.map((day) => {
             const isToday = sameDay$1(day, today);
             const isPast = day < today && !isToday;
@@ -2597,6 +2607,13 @@ AuroraCalendarWeekBox.styles = i$3 `
       text-overflow: ellipsis;
     }
 
+    .wrap-titles .chip-title {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
+    }
+
     .chip-title {
       font-size: 1em;
       font-weight: 800;
@@ -2942,7 +2959,7 @@ let AuroraCalendarTimeGrid = class AuroraCalendarTimeGrid extends i {
         const drag = this._drag;
         const pendingMove = this._pendingMove;
         return b `
-      <div class="tg-wrapper" style="--tg-day-count: ${dayCount}">
+      <div class="tg-wrapper ${this.config.wrap_event_titles ? 'wrap-titles' : ''}" style="--tg-day-count: ${dayCount}">
 
         <!-- ── Day header ── -->
         <div class="tg-header">
@@ -3532,6 +3549,15 @@ AuroraCalendarTimeGrid.styles = i$3 `
       font-family: var(--aurora-event-font-family);
     }
 
+    .wrap-titles .allday-chip {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
+      height: auto;
+      min-height: 28px;
+    }
+
     .allday-chip span:first-child {
       display: block;
       padding-right: 22px;
@@ -3645,6 +3671,10 @@ AuroraCalendarTimeGrid.styles = i$3 `
       color: var(--aurora-chip-fg);
       font-size: var(--aurora-event-font-size);
       font-family: var(--aurora-event-font-family);
+    }
+
+    .wrap-titles .ev-block {
+      overflow: visible;
     }
 
     .ev-block:hover {
@@ -3806,6 +3836,13 @@ AuroraCalendarTimeGrid.styles = i$3 `
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: 1.15;
+    }
+
+    .wrap-titles .ev-title {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
     }
 
     .ev-time {
@@ -7034,6 +7071,15 @@ let AuroraCalendarCardEditor = class AuroraCalendarCardEditor extends i {
               <ha-switch
                 .checked=${this._config.show_event_time}
                 @change=${(e) => this._set("show_event_time", e.target.checked)}
+              ></ha-switch>
+            </ha-settings-row>
+
+            <ha-settings-row>
+              <span slot="heading">${t(locale, "wrapEventTitles")}</span>
+              <span slot="description">${t(locale, "wrapEventTitlesDesc")}</span>
+              <ha-switch
+                .checked=${this._config.wrap_event_titles}
+                @change=${(e) => this._set("wrap_event_titles", e.target.checked)}
               ></ha-switch>
             </ha-settings-row>
 

--- a/src/aurora-calendar-card.ts
+++ b/src/aurora-calendar-card.ts
@@ -3243,6 +3243,15 @@ export class AuroraCalendarCardEditor extends LitElement {
               ></ha-switch>
             </ha-settings-row>
 
+            <ha-settings-row>
+              <span slot="heading">${t(locale, "wrapEventTitles")}</span>
+              <span slot="description">${t(locale, "wrapEventTitlesDesc")}</span>
+              <ha-switch
+                .checked=${this._config.wrap_event_titles}
+                @change=${(e: Event) => this._set("wrap_event_titles", (e.target as HTMLInputElement).checked)}
+              ></ha-switch>
+            </ha-settings-row>
+
             <label class="selector-control">
               <span>${t(locale, "timeFormat")}</span>
               <ha-selector

--- a/src/calendar-month.ts
+++ b/src/calendar-month.ts
@@ -91,7 +91,7 @@ export class AuroraCalendarMonth extends LitElement {
     });
 
     return html`
-      <div class="month-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"}">
+      <div class="month-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"} ${this.config.wrap_event_titles ? "wrap-titles" : ""}">
         <div class="col-headers">
           ${dayHeaders.map((d) => html`<div class="col-header">${d}</div>`)}
         </div>
@@ -685,6 +685,13 @@ export class AuroraCalendarMonth extends LitElement {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    .wrap-titles .chip-title {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
     }
 
     .chip-title {

--- a/src/calendar-month.ts
+++ b/src/calendar-month.ts
@@ -656,6 +656,12 @@ export class AuroraCalendarMonth extends LitElement {
       line-height: 1.05;
     }
 
+    .wrap-titles .chip.all-day-chip {
+      height: auto;
+      min-height: 28px;
+      overflow: visible;
+    }
+
     .all-day-stack .chip.all-day-chip:last-child {
       margin-bottom: 0;
     }

--- a/src/calendar-time.ts
+++ b/src/calendar-time.ts
@@ -182,7 +182,7 @@ export class AuroraCalendarTimeGrid extends LitElement {
     const pendingMove = this._pendingMove;
 
     return html`
-      <div class="tg-wrapper" style="--tg-day-count: ${dayCount}">
+      <div class="tg-wrapper ${this.config.wrap_event_titles ? 'wrap-titles' : ''}" style="--tg-day-count: ${dayCount}">
 
         <!-- ── Day header ── -->
         <div class="tg-header">
@@ -873,6 +873,15 @@ export class AuroraCalendarTimeGrid extends LitElement {
       font-family: var(--aurora-event-font-family);
     }
 
+    .wrap-titles .allday-chip {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
+      height: auto;
+      min-height: 28px;
+    }
+
     .allday-chip span:first-child {
       display: block;
       padding-right: 22px;
@@ -986,6 +995,10 @@ export class AuroraCalendarTimeGrid extends LitElement {
       color: var(--aurora-chip-fg);
       font-size: var(--aurora-event-font-size);
       font-family: var(--aurora-event-font-family);
+    }
+
+    .wrap-titles .ev-block {
+      overflow: visible;
     }
 
     .ev-block:hover {
@@ -1147,6 +1160,13 @@ export class AuroraCalendarTimeGrid extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: 1.15;
+    }
+
+    .wrap-titles .ev-title {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
     }
 
     .ev-time {

--- a/src/calendar-week-box.ts
+++ b/src/calendar-week-box.ts
@@ -82,7 +82,7 @@ export class AuroraCalendarWeekBox extends LitElement {
     const nextWeekLabel = this._nextWeekLabel(days);
 
     return html`
-      <div class="week-box-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"}">
+      <div class="week-box-grid ${this.config.show_calendar_grid_lines ? "" : "no-grid"} ${this.config.wrap_event_titles ? "wrap-titles" : ""}">
         ${days.map((day) => {
           const isToday = sameDay(day, today);
           const isPast = day < today && !isToday;
@@ -678,6 +678,13 @@ export class AuroraCalendarWeekBox extends LitElement {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    .wrap-titles .chip-title {
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+      overflow-wrap: break-word;
     }
 
     .chip-title {

--- a/src/calendar-week-box.ts
+++ b/src/calendar-week-box.ts
@@ -649,6 +649,12 @@ export class AuroraCalendarWeekBox extends LitElement {
       line-height: 1.05;
     }
 
+    .wrap-titles .chip.all-day-chip {
+      height: auto;
+      min-height: 28px;
+      overflow: visible;
+    }
+
     .all-day-stack .chip.all-day-chip:last-child {
       margin-bottom: 0;
     }

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -101,6 +101,8 @@ type TranslationKey =
   | "weekStartsOn"
   | "tapDayOpensDayView"
   | "tapDayOpensDayViewDesc"
+  | "wrapEventTitles"
+  | "wrapEventTitlesDesc"
   | "tapDayAria"
   | "visualBehavior";
 
@@ -182,6 +184,8 @@ const TRANSLATIONS: Record<string, TranslationMap> = {
     viewWeek: "Week",
     tapDayOpensDayView: "Tap day to open day view",
     tapDayOpensDayViewDesc: "Clicking a date number opens that day's detail view",
+    wrapEventTitles: "Wrap event titles",
+    wrapEventTitlesDesc: "Wrap long event titles onto multiple lines instead of truncating them with an ellipsis, in Week and time-grid views. Short-duration time-grid events may still get visually tight since their block height is based on duration, not title length.",
     tapDayAria: "Open day view",
     calendar: "Calendar",
     addEvent: "Add event",

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface AuroraCalendarConfig {
   event_font_family: string;
   show_calendar_grid_lines: boolean;
   keep_all_day_events_visible: boolean;
+  wrap_event_titles: boolean;
   glass_background: boolean;
   card_opacity: number;
   background_media: AuroraBackgroundMedia | null;
@@ -57,6 +58,7 @@ export const CONFIG_DEFAULTS: Omit<AuroraCalendarConfig, "type" | "integration">
   event_font_family: "inherit",
   show_calendar_grid_lines: true,
   keep_all_day_events_visible: false,
+  wrap_event_titles: false,
   glass_background: false,
   card_opacity: 100,
   background_media: null,


### PR DESCRIPTION
## What

Adds an opt-in `wrap_event_titles` config option (default `false`) that lets event titles wrap onto multiple lines instead of being truncated with an ellipsis. Off by default, so existing dashboards are unaffected.

## Where it applies

- **Week** (`calendar-week-box.ts`): safe everywhere — each day's chips are laid out in normal scrollable document flow, so a taller chip just takes more vertical space.
- **Month** and **Biweek** (`calendar-month.ts`, shared by both view modes): safe — chip height is `min-height`-based, so it grows to fit wrapped text.
- **Today** / **Next 7 Days** (`calendar-time.ts`): best-effort. These render events as absolutely-positioned blocks sized by event *duration*, not title length, so a wrapped second line on a very short (15-30 min) event can visually crowd the next event's slot on a busy day. This PR doesn't attempt to recompute block heights from content — that felt like a separate, bigger change.

## Also included

- A matching toggle in the visual editor's "Event display" section (`ha-switch`, same pattern as the existing toggles).
- English strings for the new labels (other locales fall back to English via the existing `t()` fallback, so nothing is broken for non-English users — happy to add translations if maintainers want them).
- `README.md` updated (example config block + options table).

## Testing

- `npm run build` — builds cleanly, no errors.
- `npm test` — all 34 existing frontend tests pass, no regressions.
- Backend/`.py` files are untouched.
- Manually verified on a live Home Assistant instance across Week, Biweek, Today, and Month views.

Happy to adjust naming/placement or add a config-flow migration note if you'd rather structure this differently.